### PR TITLE
fix System.lanes()

### DIFF
--- a/flint/entities/universe.py
+++ b/flint/entities/universe.py
@@ -64,9 +64,12 @@ class System(Entity):
         for first_ring in lanes:
             current_ring = first_ring
             while current_ring:
-                current_ring = rings.get(current_ring.next_ring)
-                if current_ring:
-                    lanes[first_ring].append(current_ring)
+                if current_ring.next_ring:
+                    current_ring = rings.get(current_ring.next_ring)
+                    if current_ring:
+                        lanes[first_ring].append(current_ring)
+                else:
+                    break
         return [[f, *r] for f, r in lanes.items()]  # flatten grouping dict into list of lists
 
     def region(self) -> str:


### PR DESCRIPTION
Turns out System.lanes() is completely broken. As soon as it encounters the last ring in a lane, `rings.get(current_ring.next_ring)` will throw an exception. This PR works around that.

Alternatively, this could also be fixed by altering EntitySet.get()'s behaviour to include default values, which it looks like was the expected behaviour here